### PR TITLE
biter-battles: mvp stats only get sent once

### DIFF
--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -342,7 +342,8 @@ function Public.silo_death(event)
 		
 		Server.to_discord_embed(c .. " has won!")
 		Server.to_discord_embed(global.victory_time)
-		
+		global.results_sent_south = false
+		global.results_sent_north = false
 		silo_kaboom(entity)
 		
 		freeze_all_biters(entity.surface)


### PR DESCRIPTION
Fixing flags so it resets at the end of the game so that the MVPs get sent after every game