### PR TITLE
biter battle: send chat to discord even during tournament

### DIFF
--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -232,6 +232,7 @@ function Public.share_chat(event)
 	local color = player.chat_color
 
 	local msg = player.name .. tag .. " (" .. player.force.name .. "): ".. event.message
+	Server.to_discord_player_chat(msg)
 	
 	if player.force.name == "north" then
 		game.forces.spectator.print(player.name .. tag .. " (north): ".. event.message, color)		
@@ -263,7 +264,7 @@ function Public.share_chat(event)
 		end
 	end
 
-	Server.to_discord_player_chat(msg)
+
 end
 
 function Public.spy_fish(player)


### PR DESCRIPTION
Previously, the send to discord line was after the ```if global.tournament_mode then return end``` which means that no player chat is sent to discord when tournament mode is enabled. 

Moving it earlier so that player chat is still sent during tournament mode.

Compiles and tested