### PR TITLE
Centralize ammo modifier values

### DIFF
--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -1,4 +1,5 @@
 local Server = require 'utils.server'
+local Tables = require "maps.biter_battles_v2.tables"
 local string_sub = string.sub
 local math_random = math.random
 local math_round = math.round
@@ -7,39 +8,29 @@ local table_insert = table.insert
 local table_remove = table.remove
 local string_find = string.find
 
+-- Only add upgrade research balancing logic in this section
+-- All values should be in tables.lua
 local balance_functions = {
-	["flamethrower"] = function(force_name)
-		global.combat_balance[force_name].flamethrower_damage = -0.8
-		game.forces[force_name].set_turret_attack_modifier("flamethrower-turret", global.combat_balance[force_name].flamethrower_damage)
-		game.forces[force_name].set_ammo_damage_modifier("flamethrower", global.combat_balance[force_name].flamethrower_damage)
-	end,
 	["refined-flammables"] = function(force_name)
-		global.combat_balance[force_name].flamethrower_damage = global.combat_balance[force_name].flamethrower_damage + 0.02
+		if not global.combat_balance[force_name].flamethrower_damage then global.combat_balance[force_name].flamethrower_damage = get_ammo_modifier("flamethrower") end
+		global.combat_balance[force_name].flamethrower_damage = global.combat_balance[force_name].flamethrower_damage + get_upgrade_modifier("flamethrower")
 		game.forces[force_name].set_turret_attack_modifier("flamethrower-turret", global.combat_balance[force_name].flamethrower_damage)								
 		game.forces[force_name].set_ammo_damage_modifier("flamethrower", global.combat_balance[force_name].flamethrower_damage)
 	end,
-	["land-mine"] = function(force_name)
-		if not global.combat_balance[force_name].land_mine then global.combat_balance[force_name].land_mine = -.9 end
-		game.forces[force_name].set_ammo_damage_modifier("landmine", global.combat_balance[force_name].land_mine)
-	end,
 	
 	["stronger-explosives"] = function(force_name)
-		global.combat_balance[force_name].grenade_damage = global.combat_balance[force_name].grenade_damage + 0.4					
+		if not global.combat_balance[force_name].grenade_damage then global.combat_balance[force_name].grenade_damage = get_ammo_modifier("grenade") end			
+		global.combat_balance[force_name].grenade_damage = global.combat_balance[force_name].grenade_damage + get_upgrade_modifier("grenade")
 		game.forces[force_name].set_ammo_damage_modifier("grenade", global.combat_balance[force_name].grenade_damage)
 
-		if not global.combat_balance[force_name].land_mine then global.combat_balance[force_name].land_mine = -0.9 end
-		global.combat_balance[force_name].land_mine = global.combat_balance[force_name].land_mine + 0.03								
+		if not global.combat_balance[force_name].land_mine then global.combat_balance[force_name].land_mine = get_ammo_modifier("landmine") end
+		global.combat_balance[force_name].land_mine = global.combat_balance[force_name].land_mine + get_upgrade_modifier("landmine")								
 		game.forces[force_name].set_ammo_damage_modifier("landmine", global.combat_balance[force_name].land_mine)
 	end,
-	["military"] = function(force_name)
-		global.combat_balance[force_name].shotgun = 1
-		game.forces[force_name].set_ammo_damage_modifier("shotgun-shell", global.combat_balance[force_name].shotgun)
-	end,
-
 	["physical-projectile-damage"] = function(force_name)
-		global.combat_balance[force_name].shotgun = global.combat_balance[force_name].shotgun + 0.6
+		if not global.combat_balance[force_name].shotgun then global.combat_balance[force_name].shotgun = get_ammo_modifier("shotgun-shell") end
+		global.combat_balance[force_name].shotgun = global.combat_balance[force_name].shotgun + get_upgrade_modifier("shotgun-shell")	
 		game.forces[force_name].set_ammo_damage_modifier("shotgun-shell", global.combat_balance[force_name].shotgun)
-		
 	end,
 }
 
@@ -326,6 +317,22 @@ function Public.map_intro_click(player, element)
 			return true
 		end
 	end	
+end
+
+function get_ammo_modifier(ammo_category)
+	local result = 0
+	if Tables.base_ammo_modifiers[ammo_category] then
+        result = Tables.base_ammo_modifiers[ammo_category]
+	end
+    return result
+end
+
+function get_upgrade_modifier(ammo_category)
+    result = 0
+    if Tables.upgrade_modifiers[ammo_category] then
+        result = Tables.upgrade_modifiers[ammo_category]
+    end
+    return result
 end
 
 return Public

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -274,6 +274,14 @@ function Public.forces()
 		end
 	end
 
+	for _, force in pairs(Tables.ammo_modified_forces_list) do
+		for turret_category, value in pairs(Tables.base_turret_attack_modifiers) do
+			game.print(turret_category)
+			game.forces[force]
+				.set_turret_attack_modifier(turret_category, value)
+		end
+	end
+
 end
 
 return Public

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -1,6 +1,7 @@
 local Terrain = require "maps.biter_battles_v2.terrain"
 local Force_health_booster = require "modules.force_health_booster"
 local Score = require "comfy_panel.score"
+local Tables = require "maps.biter_battles_v2.tables"
 
 local Public = {}
 
@@ -264,11 +265,15 @@ function Public.forces()
 		global.bb_evolution[force.name] = 0
 		global.bb_threat_income[force.name] = 0
 		global.bb_threat[force.name] = 0
-		game.forces["south"].set_ammo_damage_modifier("bullet", 0.2)
-		game.forces["north"].set_ammo_damage_modifier("bullet", 0.2)
-		-- game.forces["south"].set_ammo_damage_modifier("grenade", -0.5)
-		-- game.forces["north"].set_ammo_damage_modifier("grenade", -0.5)
 	end
+	for _, force in pairs(Tables.ammo_modified_forces_list) do
+		for ammo_category, value in pairs(Tables.base_ammo_modifiers) do
+			game.print(ammo_category)
+			game.forces[force]
+				.set_ammo_damage_modifier(ammo_category, value)
+		end
+	end
+
 end
 
 return Public

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -268,7 +268,6 @@ function Public.forces()
 	end
 	for _, force in pairs(Tables.ammo_modified_forces_list) do
 		for ammo_category, value in pairs(Tables.base_ammo_modifiers) do
-			game.print(ammo_category)
 			game.forces[force]
 				.set_ammo_damage_modifier(ammo_category, value)
 		end
@@ -276,7 +275,6 @@ function Public.forces()
 
 	for _, force in pairs(Tables.ammo_modified_forces_list) do
 		for turret_category, value in pairs(Tables.base_turret_attack_modifiers) do
-			game.print(turret_category)
 			game.forces[force]
 				.set_turret_attack_modifier(turret_category, value)
 		end

--- a/maps/biter_battles_v2/tables.lua
+++ b/maps/biter_battles_v2/tables.lua
@@ -5,7 +5,8 @@ Public.ammo_modified_forces_list = {"north", "south", "spectator"}
 
 -- Ammo modifiers via set_ammo_damage_modifier
 -- [ammo_category] = value
--- damage = base_damage + (base_damage*ammo_modifier)
+-- ammo_modifier_dmg = base_damage * base_ammo_modifiers
+-- damage = base_damage + ammo_modifier_dmg
 Public.base_ammo_modifiers = {
 	["bullet"] = 0.2,
 	["shotgun-shell"] = 1,
@@ -13,12 +14,16 @@ Public.base_ammo_modifiers = {
 	["landmine"] = -0.9
 }
 
+-- turret attack modifier via set_turret_attack_modifier
 Public.base_turret_attack_modifiers = {
 	["flamethrower-turret"] = -0.8
 }
 
 Public.upgrade_modifiers = {
-	["shotgun-shell"] = 0.6
+	["flamethrower"] = 0.02,
+	["shotgun-shell"] = 0.6,
+	["grenade"] = 0.4,
+	["landmine"] = 0.03
 }
 
 Public.food_values = {

--- a/maps/biter_battles_v2/tables.lua
+++ b/maps/biter_battles_v2/tables.lua
@@ -13,7 +13,7 @@ Public.base_ammo_modifiers = {
 	["landmine"] = -0.9
 }
 
-Public.turret_attack_modifiers = {
+Public.base_turret_attack_modifiers = {
 	["flamethrower-turret"] = -0.8
 }
 

--- a/maps/biter_battles_v2/tables.lua
+++ b/maps/biter_battles_v2/tables.lua
@@ -1,5 +1,26 @@
 local Public = {}
 
+-- List of forces that will be affected by ammo modifier
+Public.ammo_modified_forces_list = {"north", "south", "spectator"}
+
+-- Ammo modifiers via set_ammo_damage_modifier
+-- [ammo_category] = value
+-- damage = base_damage + (base_damage*ammo_modifier)
+Public.base_ammo_modifiers = {
+	["bullet"] = 0.2,
+	["shotgun-shell"] = 1,
+	["flamethrower"] = -0.8,
+	["landmine"] = -0.9
+}
+
+Public.turret_attack_modifiers = {
+	["flamethrower-turret"] = -0.8
+}
+
+Public.upgrade_modifiers = {
+	["shotgun-shell"] = 0.6
+}
+
 Public.food_values = {
 	["automation-science-pack"] =		{value = 0.000505, name = "automation science", color = "255, 50, 50"},
 	["logistic-science-pack"] =		{value = 0.00155, name = "logistic science", color = "50, 255, 50"},


### PR DESCRIPTION
Put damage modifiers to tables.lua.

- Will make it easier to make a future change to add values in gui
- Will reduce chances of logic overwriting each other


I tested it and compared damage values against 1v1 server (cause it was empty). 

You might have to rebalance grenades. 
Original value is nil, so this doesn't really do anything.
```		
global.combat_balance[force_name].grenade_damage = global.combat_balance[force_name].grenade_damage + 0.4	
```



* If there's a base modifier, spectators will not see the research upgrade values