### PR TITLE
Improve Biter Behavior

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -225,13 +225,7 @@ local function select_units_around_spawner(spawner, force_name, side_target)
 	return valid_biters
 end
 
-local function send_group(unit_group, force_name, side_target)
-	local target
-	if side_target then
-		target = side_target
-	else
-		target = get_target_entity(force_name) 
-	end
+local function send_group(unit_group, force_name, target)
 	if not target then print("No target for " .. force_name .. " biters.") return end
 	
 	target = target.position
@@ -332,7 +326,7 @@ local function create_attack_group(surface, force_name, biter_force_name)
 		return false 
 	end	
 	
-	local side_target = get_target_entity(force_name)
+	local side_target = global.rocket_silo[force_name]
 	if not side_target then
 		print("No side target found for " .. force_name .. ".")
 		return

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -311,13 +311,13 @@ local function create_attack_group(surface, force_name, biter_force_name)
 		return false 
 	end	
 	
-	local side_target = global.rocket_silo[force_name]
-	if not side_target then
-		print("No side target found for " .. force_name .. ".")
+	local target = global.rocket_silo[force_name]
+	if not target then
+		print("No target found for " .. force_name .. ".")
 		return
 	end
 	
-	local spawner = get_nearby_biter_nest(side_target)
+	local spawner = get_nearby_biter_nest(target)
 	if not spawner then
 		print("No spawner found for " .. force_name .. ".")
 		return
@@ -326,13 +326,13 @@ local function create_attack_group(surface, force_name, biter_force_name)
 	local unit_group_position = get_unit_group_position(spawner)
 	if not unit_group_position then return end
 	
-	local units = select_units_around_spawner(spawner, force_name, side_target)
+	local units = select_units_around_spawner(spawner, force_name, target)
 	if not units then return end
 	
 	local unit_group = surface.create_unit_group({position = unit_group_position, force = biter_force_name})
 	for _, unit in pairs(units) do unit_group.add_member(unit) end
 	
-	send_group(unit_group, force_name, side_target)
+	send_group(unit_group, force_name, target)
 	
 	global.unit_groups[unit_group.group_number] = unit_group
 end

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -211,13 +211,11 @@ end
 local function send_group(unit_group, force_name)
 	local target = global.rocket_silo[force_name]
 	
-	target = target.position
-	
 	local commands = {}	
 	local vector = attack_vectors[force_name][math_random(1, size_of_vectors)]
 	local distance_modifier = math_random(25, 100) * 0.01
 	
-	local position = {target.x + (vector[1] * distance_modifier), target.y + (vector[2] * distance_modifier)}
+	local position = {target.position.x + (vector[1] * distance_modifier), target.position.y + (vector[2] * distance_modifier)}
 	position = unit_group.surface.find_non_colliding_position("stone-furnace", position, 96, 1)
 	if position then
 		if math.abs(position.y) < math.abs(unit_group.position.y) then

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -9,14 +9,12 @@ local vector_radius = 512
 local attack_vectors = {}
 attack_vectors.north = {}
 attack_vectors.south = {}
-for x = vector_radius * -1, vector_radius, 1 do
-	for y = 0, vector_radius, 1 do
-		local r = math.sqrt(x ^ 2 + y ^ 2)
-		if r < vector_radius and r > vector_radius - 1 then
-			attack_vectors.north[#attack_vectors.north + 1] = {x, y * -1}
-			attack_vectors.south[#attack_vectors.south + 1] = {x, y}
-		end
-	end
+for p = 0.3, 0.71, 0.05 do
+	local a = math.pi * p
+	local x = vector_radius * math.cos(a)
+	local y = vector_radius * math.sin(a)
+	attack_vectors.north[#attack_vectors.north + 1] = {x, y * -1}
+	attack_vectors.south[#attack_vectors.south + 1] = {x, y}
 end
 local size_of_vectors = #attack_vectors.north
 

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -263,7 +263,7 @@ local function send_group(unit_group, force_name, side_target)
 	commands[#commands + 1] = {
 		type = defines.command.attack,
 		target = global.rocket_silo[force_name],
-		distraction = defines.distraction.by_enemy
+		distraction = defines.distraction.by_damage
 	}
 	
 	unit_group.set_command({

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -210,8 +210,8 @@ local function select_units_around_spawner(spawner, force_name, side_target)
 	return valid_biters
 end
 
-local function send_group(unit_group, force_name, target)
-	if not target then print("No target for " .. force_name .. " biters.") return end
+local function send_group(unit_group, force_name)
+	local target = global.rocket_silo[force_name]
 	
 	target = target.position
 	
@@ -233,15 +233,8 @@ local function send_group(unit_group, force_name, target)
 	end
 	
 	commands[#commands + 1] = {
-		type = defines.command.attack_area,
-		destination = target,
-		radius = 32,
-		distraction = defines.distraction.by_enemy
-	}
-	
-	commands[#commands + 1] = {
 		type = defines.command.attack,
-		target = global.rocket_silo[force_name],
+		target = target,
 		distraction = defines.distraction.by_damage
 	}
 	
@@ -332,7 +325,7 @@ local function create_attack_group(surface, force_name, biter_force_name)
 	local unit_group = surface.create_unit_group({position = unit_group_position, force = biter_force_name})
 	for _, unit in pairs(units) do unit_group.add_member(unit) end
 	
-	send_group(unit_group, force_name, target)
+	send_group(unit_group, force_name)
 	
 	global.unit_groups[unit_group.group_number] = unit_group
 end

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -48,21 +48,6 @@ local function get_active_biter_count(biter_force_name)
 	return count
 end
 
-local function get_target_entity(force_name)
-	local force_index = game.forces[force_name].index	
-	local target_entity = Functions.get_random_target_entity(force_index)
-	if not target_entity then print("Unable to get target entity for " .. force_name .. ".") return end	
-	for _ = 1, 2, 1 do
-		local e = Functions.get_random_target_entity(force_index)
-		if math_abs(e.position.x) < math_abs(target_entity.position.x) then
-			target_entity = e
-		end
-	end	
-	if not target_entity then print("Unable to get target entity for " .. force_name .. ".") return end	
-	--print("Target entity for " .. force_name .. ": " .. target_entity.name .. " at x=" .. target_entity.position.x .. " y=" .. target_entity.position.y)
-	return target_entity
-end
-
 local function get_threat_ratio(biter_force_name)
 	if global.bb_threat[biter_force_name] <= 0 then return 0 end
 	local t1 = global.bb_threat["north_biters"]

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -49,24 +49,6 @@ local landfill_biters = {
 	["behemoth-spitter"] = true,
 }
 
-local target_entity_types = {
-	["assembling-machine"] = true,
-	["boiler"] = true,
-	["furnace"] = true,
-	["generator"] = true,
-	["lab"] = true,
-	["mining-drill"] = true,
-	["radar"] = true,
-	["reactor"] = true,
-	["roboport"] = true,
-	["rocket-silo"] = true,
-	["ammo-turret"] = true,
-	["artillery-turret"] = true,
-	["beacon"] = true,
-	["electric-turret"] = true,
-	["fluid-turret"] = true,
-}
-
 local spawn_positions = {}
 local spawn_r = 7
 local spawn_r_square = spawn_r ^ 2
@@ -80,30 +62,6 @@ end
 local size_of_spawn_positions = #spawn_positions
 
 local Public = {}
-
-function Public.add_target_entity(entity)
-	if not entity then return end
-	if not entity.valid then return end
-	if not target_entity_types[entity.type] then return end
-	table_insert(global.target_entities[entity.force.index], entity)
-end
-
-function Public.get_random_target_entity(force_index)
-	local target_entities = global.target_entities[force_index]
-	local size_of_target_entities = #target_entities
-	if size_of_target_entities == 0 then return end
-	for _ = 1, size_of_target_entities, 1 do
-		local i = math_random(1, size_of_target_entities)
-		local entity = target_entities[i]
-		if entity and entity.valid then
-			return entity
-		else
-			table_remove(target_entities, i)
-			size_of_target_entities = size_of_target_entities - 1
-			if size_of_target_entities == 0 then return end
-		end
-	end
-end
 
 function Public.get_health_modifier(force)
 	if global.bb_evolution[force.name] < 1 then return 1 end

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -44,13 +44,11 @@ end
 
 local function on_built_entity(event)
 	Functions.no_turret_creep(event)
-	Functions.add_target_entity(event.created_entity)
 end
 
 local function on_robot_built_entity(event)
 	Functions.no_turret_creep(event)
 	Terrain.deny_construction_bots(event)
-	Functions.add_target_entity(event.created_entity)
 end
 
 local function on_robot_built_tile(event)

--- a/maps/biter_battles_v2/mirror_terrain.lua
+++ b/maps/biter_battles_v2/mirror_terrain.lua
@@ -75,7 +75,6 @@ local entity_copy_functions = {
 		if surface.count_entities_filtered({name = "rocket-silo", area = {{target_position.x - 8, target_position.y - 8},{target_position.x + 8, target_position.y + 8}}}) > 0 then return end
 		global.rocket_silo[force_name] = surface.create_entity({name = entity.name, position = target_position, direction = direction_translation[entity.direction], force = force_name})
 		global.rocket_silo[force_name].minable = false
-		Functions.add_target_entity(global.rocket_silo[force_name])
 	end,	
 	["ammo-turret"] = function(surface, entity, target_position, force_name)
 		local direction = 0
@@ -83,7 +82,6 @@ local entity_copy_functions = {
 		local mirror_entity = {name = entity.name, position = target_position, force = force_name, direction = direction}
 		if not surface.can_place_entity(mirror_entity) then return end
 		local e = surface.create_entity(mirror_entity)
-		Functions.add_target_entity(e)
 		local inventory = entity.get_inventory(defines.inventory.turret_ammo)
 		if inventory.is_empty() then return end
 		for name, count in pairs(inventory.get_contents()) do e.insert({name = name, count = count}) end	


### PR DESCRIPTION
### Brief description of the changes:
Biters will currently go to random position around the silo (in an arc) and then to the silo.
Effectively it does the following:
* removes attacks on outposts,
* makes games quicker (they should stop idling around the silo or waste time by chasing players),
* slightly improves performance as `on_built_entity` is shorter and most player's entities aren't kept in lua memory.
More details in commit messages.

It big change to biter behavior and should probably be tested/discussed with the community first,

Closes  #45.

### Tested Changes
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
