### PR TITLE
Notifies both teams when a new level of biter spawns

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -218,6 +218,11 @@ local function select_units_around_spawner(spawner, force_name, side_target)
 		i = i + 1
 		valid_biters[i] = biter
 		global.active_biters[biter.force.name][biter.unit_number] = {entity = biter, active_since = game.tick}
+		--Announce New Spawn
+		if(global.biter_spawn_unseen[force_name][unit_name]) then
+			game.print("A " .. unit_name:gsub("-", " ") .. " was spotted far away on team " .. force_name .. "...")
+			global.biter_spawn_unseen[force_name][unit_name] = false
+		end
 	end
 		
 	if global.bb_debug then game.print(get_active_biter_count(biter_force_name) .. " active units for " .. biter_force_name) end

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -166,6 +166,14 @@ function Public.tables()
 	global.unit_spawners = {}
 	global.unit_spawners.north_biters = {}
 	global.unit_spawners.south_biters = {}
+	global.biter_spawn_unseen = {
+		["north"] = {
+			["medium-spitter"] = true, ["medium-biter"] = true, ["big-spitter"] = true, ["big-biter"] = true, ["behemoth-spitter"] = true, ["behemoth-biter"] = true
+		},
+		["south"] = {
+			["medium-spitter"] = true, ["medium-biter"] = true, ["big-spitter"] = true, ["big-biter"] = true, ["behemoth-spitter"] = true, ["behemoth-biter"] = true
+		}
+	}
 	global.difficulty_votes_timeout = 36000
 	global.next_attack = "north"
 	if math.random(1,2) == 1 then global.next_attack = "south" end

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -1,6 +1,6 @@
 local Public = {}
 local LootRaffle = require "functions.loot_raffle"
-local BiterRaffle = require "functions.biter_raffle"
+local BiterRaffle = require "maps.biter_battles_v2.biter_raffle"
 local bb_config = require "maps.biter_battles_v2.config"
 
 local table_insert = table.insert


### PR DESCRIPTION
### Brief description of the changes:
Fixes #76, use consistent maps/biter_battles_v2/biter_raffle.lua

Added warning flags when a new level of biter is spawned in the form:
`A medium spitter was spotted far away on team north...`
Warnings only occur on the first spawn of that level.
Small spitters and biters are ignored.

Let me know if the text should be different or a specific colour

### Tested Changes
Tested via sending science and viewing the notifications display at various evolution factors.
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
