### PR TITLE
difficulty-votes: clear vote table on revote

### DIFF
--- a/commands/difficulty_voting_commands.lua
+++ b/commands/difficulty_voting_commands.lua
@@ -12,6 +12,7 @@ local function revote()
         else
             local tick = game.ticks_played
             global.difficulty_votes_timeout = tick + 10800
+            global.difficulty_player_votes = {}
             msg = player.name .. " opened difficulty voting. Voting enabled for 3 mins"
             game.print(msg)
             Server.to_discord_embed(msg)


### PR DESCRIPTION
### Brief description of the changes:
Clear vote table on revote 
Clearing the votes will encourage actual re-voting. 1hr in, I doubt people remember their votes, so it's best to just revote. 
Upon re-voting, the difficulty level will get re-calculated similar to the logic in the beginning of the game. 

### Tested Changes
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
