### PR TITLE
Update tables.lua

### DIFF
--- a/maps/biter_battles_v2/tables.lua
+++ b/maps/biter_battles_v2/tables.lua
@@ -10,19 +10,21 @@ Public.ammo_modified_forces_list = {"north", "south", "spectator"}
 Public.base_ammo_modifiers = {
 	["bullet"] = 0.2,
 	["shotgun-shell"] = 1,
-	["flamethrower"] = -0.8,
-	["landmine"] = -0.9
+	["flamethrower"] = -0.75,
+	["landmine"] = -0.9,
+	["grenade"] = -0.6
 }
 
 -- turret attack modifier via set_turret_attack_modifier
 Public.base_turret_attack_modifiers = {
-	["flamethrower-turret"] = -0.8
+	["flamethrower-turret"] = -0.75
 }
 
 Public.upgrade_modifiers = {
-	["flamethrower"] = 0.02,
+	["flamethrower"] = 0.03,
 	["shotgun-shell"] = 0.6,
-	["grenade"] = 0.4,
+	["grenade"] = 0.5,
+	["bullet"] = 0.35,
 	["landmine"] = 0.03
 }
 


### PR DESCRIPTION
### Brief description of the changes:
Grenade Balance: Nerf grenade starting damage by 40% and buff upgrade damage by 25% (40% > 50%). 
Flame Buff: upgrade damage by 50% (.02 > .03)  and buff starting damage by 25% (-.8 > -.75)
Bullet Buff: Increase bullet upgrade damage by 75%. (20%>35 or 40%)

### Tested Changes
- [] I've tested the changes locally or with people.
- [x] I've not tested the changes.
