### PR TITLE
Added 10 burner miner drills when player spawns

### DIFF
--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -328,6 +328,7 @@ function join_team(player, force_name, forced_join)
 	player.insert {name = 'firearm-magazine', count = 32}
 	player.insert {name = 'iron-gear-wheel', count = 8}
 	player.insert {name = 'iron-plate', count = 16}
+	player.insert {name = 'burner-mining-drill', count = 10}
 	global.chosen_team[player.name] = force_name
 	player.spectator = false
 	Public.refresh()


### PR DESCRIPTION
### Brief description of the changes:
The board decided to try speeding up the initial burner phase.
They decided to provide 10 starting burner miner drill to each player.

Tested code in game, and it works.

### Tested Changes
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
