### PR TITLE
Fixup silo research changes

### DIFF
--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -142,7 +142,7 @@ local function on_init()
 end
 
 local Event = require 'utils.event'
-script.on_event(defines.events.on_research_finished, Ai.unlock_satellite)			--free silo space tech
+Event.add(defines.events.on_research_finished, Ai.unlock_satellite)			--free silo space tech
 Event.add(defines.events.on_built_entity, on_built_entity)
 Event.add(defines.events.on_chunk_generated, on_chunk_generated)
 Event.add(defines.events.on_console_chat, on_console_chat)


### PR DESCRIPTION
### Brief description of the changes:
Event was added in a way that prevented other hooks from firing.

### Tested Changes
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.

Started scenario locally. In editor mode researched `shooting speed 1`. Observed `-80%` bonus on flamers and `+100%` on shotgun. Researched `speed module 3`. Observed that `silo` and `space science` are completed without researching.